### PR TITLE
Remove need to do "say", but still allow it

### DIFF
--- a/bin/crag
+++ b/bin/crag
@@ -12,12 +12,12 @@ sub MAIN(
             Usage:
                 ./crag [--help] <cmd>
             Examples:
-                [1] > crag 'say (1.6km / (60 * 60 * 1s)).in: <mph>'               #0.99mph
-                [2] > crag '$m=95kg; $a=^<9.81 m/s^2>; $f=$m*$a; say $f'          #931.95N
-                [3] > crag 'say ^<12.5 ft ±3%> .in: <mm>'                         #3810mm ±114.3
-                [4] > crag '$λ=2.5nm; $ν=c/$λ; say $ν.norm'                       #119.91PHz
-                [5] > crag '$c=^<37 °C>; $f=^<98.6 °F>; say $f cmp $c'            #Same
-                [6] > crag 'say @physics-constants-symbols.join: "\n"'            # ...
+                [1] > crag '(1.6km / (60 * 60 * 1s)).in: <mph>'        #0.99mph
+                [2] > crag '$m=95kg; $a=^<9.81 m/s^2>; $m*$a'          #931.95N
+                [3] > crag '^<12.5 ft ±3%> .in: <mm>'                  #3810mm ±114.3
+                [4] > crag '$λ=2.5nm; $ν=c/$λ; $ν.norm'                #119.91PHz
+                [5] > crag '$c=^<37 °C>; $f=^<98.6 °F>; $f cmp $c'     #Same
+                [6] > crag '@physics-constants-symbols.join: "\n"'     # ...
             More info:
                 - https://github.com/librasteve/raku-Physics-Measure.git
                 - https://github.com/librasteve/raku-Physics-Unit.git
@@ -31,6 +31,10 @@ sub MAIN(
             - echo RAKULANG='en_US' for us gallons, pints, mpg, etc.
             END
     } else {
-        eval-me($cmd);
+        my $out   := $*OUT.tell;
+        my $value := eval-me($cmd);
+        if $*OUT.tell == $out {
+            say $value;
+        }
     }
 }


### PR DESCRIPTION
This checks the position of STDOUT before and after the EVAL, and says the value if there has not been anything printed on STDOUT.

Allows one to focus on the calculation, rather than the need to output the result.